### PR TITLE
Update Spring Boot to 3.5.4 and ensure client tests pass

### DIFF
--- a/client/src/main/java/dev/sobue/workshop/client/ClientApplication.java
+++ b/client/src/main/java/dev/sobue/workshop/client/ClientApplication.java
@@ -2,6 +2,8 @@ package dev.sobue.workshop.client;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestClient;
 
 /**
  * Main Class.
@@ -18,5 +20,10 @@ public class ClientApplication {
    */
   public static void main(String[] args) {
     SpringApplication.run(ClientApplication.class, args);
+  }
+
+  @Bean
+  RestClient restClient() {
+    return RestClient.builder().build();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.3</version>
+        <version>3.5.4</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
## Summary
- Upgrade project to Spring Boot 3.5.4
- Provide a `RestClient` bean so the client module's context loads during tests

## Testing
- `mvn -e -ntp verify`


------
https://chatgpt.com/codex/tasks/task_e_6898957c1d6483329de33d6275b13b0b