### PR TITLE
Add Markdown lint workflow for docs

### DIFF
--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -1,0 +1,24 @@
+name: Docs Markdown Lint
+
+on:
+  push:
+    paths:
+      - 'docs/**/*.md'
+      - '.github/workflows/markdown-lint.yaml'
+  pull_request:
+    paths:
+      - 'docs/**/*.md'
+      - '.github/workflows/markdown-lint.yaml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint Markdown with Super-Linter
+        uses: super-linter/super-linter@v7
+        env:
+          DEFAULT_BRANCH: main
+          VALIDATE_MARKDOWN: true
+          FILTER_REGEX_INCLUDE: docs/.*\\.md
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -18,9 +18,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Lint Markdown with Super-Linter
-        uses: super-linter/super-linter@v7
+        uses: super-linter/super-linter@v8.3.1
         env:
           DEFAULT_BRANCH: main
           VALIDATE_MARKDOWN: true
           FILTER_REGEX_INCLUDE: docs/.*\\.md
+          OUTPUT_DETAILS: detailed
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Lint Markdown with Super-Linter
         uses: super-linter/super-linter@v7
         env:

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -17,10 +17,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Ensure default branch is present
+        run: git fetch origin $DEFAULT_BRANCH:$DEFAULT_BRANCH
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       - name: Lint Markdown with Super-Linter
         uses: super-linter/super-linter@v8.3.1
         env:
-          DEFAULT_BRANCH: main
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           VALIDATE_MARKDOWN: true
           FILTER_REGEX_INCLUDE: docs/.*\\.md
           OUTPUT_DETAILS: detailed


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run Super-Linter
- limit linting to Markdown files under docs
- trigger on changes to docs Markdown or the workflow file


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a44cc168c83328a449aadd85b8676)